### PR TITLE
Update `ManagerAgent` to handle different SQL query types and return …

### DIFF
--- a/src/main/java/com/fmoreno/telegramtaskaiagent/agents/ManagerAgent.java
+++ b/src/main/java/com/fmoreno/telegramtaskaiagent/agents/ManagerAgent.java
@@ -16,6 +16,11 @@ public class ManagerAgent {
   }
 
   public String processUserMessage(String messageText, String sqlQuery, String executionResult, String userName) {
+    String responseMessage = generateResponseMessage(sqlQuery, executionResult);
+    if (responseMessage != null) {
+      return responseMessage;
+    }
+
     String promptText = buildPrompt(messageText, sqlQuery, executionResult, userName);
     log.info("Prompt text: {}", promptText);
     return generateResponse(promptText);
@@ -58,5 +63,17 @@ public class ManagerAgent {
         .getResult()
         .getOutput()
         .getContent();
+  }
+
+  private String generateResponseMessage(String sqlQuery, String executionResult) {
+    String lowerCaseQuery = sqlQuery.toLowerCase().trim();
+    if (lowerCaseQuery.startsWith("insert")) {
+      return "Tarea creada correctamente.";
+    } else if (lowerCaseQuery.startsWith("update")) {
+      return "Tarea modificada correctamente.";
+    } else if (lowerCaseQuery.startsWith("delete")) {
+      return "Tarea eliminada correctamente.";
+    }
+    return null;
   }
 }

--- a/src/test/java/com/fmoreno/telegramtaskaiagent/agents/ManagerAgentTestIT.java
+++ b/src/test/java/com/fmoreno/telegramtaskaiagent/agents/ManagerAgentTestIT.java
@@ -12,7 +12,6 @@ import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-// TODO fix the test with the RelevancyEvaluator
 @Log4j2
 public class ManagerAgentTestIT extends CommonTestIT {
 
@@ -46,9 +45,7 @@ public class ManagerAgentTestIT extends CommonTestIT {
 
         log.info("Response: {}", response);
         assertNotNull(response);
-        assertTrue(response.contains("creado la tarea"));
-        assertTrue(response.contains("jugar al basket"));
-        assertTrue(response.contains("Fernando"));
+        assertEquals("Tarea creada correctamente.", response);
     }
 
     @Test
@@ -83,9 +80,7 @@ public class ManagerAgentTestIT extends CommonTestIT {
         log.info("Response: {}", response);
 
         assertNotNull(response);
-        assertTrue(response.contains("modificado la tarea"));
-        assertTrue(response.contains("Comprar groceries"));
-        assertTrue(response.contains("Comprar verduras"));
+        assertEquals("Tarea modificada correctamente.", response);
     }
 
     @Test
@@ -100,8 +95,7 @@ public class ManagerAgentTestIT extends CommonTestIT {
         String response = managerAgent.processUserMessage(userMessage, sql, executionResult, "Fernando");
 
         assertNotNull(response);
-        assertTrue(response.contains("eliminado la tarea"));
-        assertTrue(response.contains("Llamar al médico"));
+        assertEquals("Tarea eliminada correctamente.", response);
     }
 
     @Test
@@ -116,7 +110,6 @@ public class ManagerAgentTestIT extends CommonTestIT {
         String response = managerAgent.processUserMessage(userMessage, sql, executionResult, "Fernando");
 
         assertNotNull(response);
-        assertTrue(response.contains("error"));
-        assertTrue(response.contains("No se pudo crear la tarea"));
+        assertTrue(response.contains("Error al ejecutar la consulta"));
     }
 }

--- a/src/test/java/com/fmoreno/telegramtaskaiagent/client/TelegramClientConfigTestIT.java
+++ b/src/test/java/com/fmoreno/telegramtaskaiagent/client/TelegramClientConfigTestIT.java
@@ -196,4 +196,136 @@ class TelegramClientConfigTestIT extends CommonTestIT {
         Optional<UserEntity> allowedUserEntityOptional = userRepository.findByEmail(allowedEmail);
         assertThat(allowedUserEntityOptional).isPresent();
     }
+
+    @Test
+    void testCreateTaskResponse() throws Exception {
+        // given
+        String message = "Crea una nueva tarea";
+        Update update = new Update();
+        Message telegramMessage = new Message();
+        telegramMessage.setText(message);
+        telegramMessage.setChat(new Chat(9L, "private"));
+        User user = new User(1L, "TestUser", false);
+        telegramMessage.setFrom(user);
+        update.setMessage(telegramMessage);
+
+        // Add user to the test database
+        UserEntity userEntity = new UserEntity();
+        userEntity.setUserId(user.getId());
+        userEntity.setEmail("allowed1@example.com");
+        userEntity.setFirstName(user.getFirstName());
+        userEntity.setLastName(user.getLastName());
+        userEntity.setUserName(user.getUserName());
+        userRepository.save(userEntity);
+
+        ArgumentCaptor<SendMessage> argumentCaptor = ArgumentCaptor.forClass(SendMessage.class);
+        org.mockito.Mockito.doReturn(null).when(telegramClient).execute(argumentCaptor.capture());
+
+        // when
+        telegramClientConfig.consume(update);
+
+        // then
+        SendMessage capturedMessage = argumentCaptor.getValue();
+        assertThat(capturedMessage).isNotNull();
+        assertThat(capturedMessage.getText()).isEqualTo("Tarea creada correctamente.");
+    }
+
+    @Test
+    void testUpdateTaskResponse() throws Exception {
+        // given
+        String message = "Actualiza la tarea existente";
+        Update update = new Update();
+        Message telegramMessage = new Message();
+        telegramMessage.setText(message);
+        telegramMessage.setChat(new Chat(9L, "private"));
+        User user = new User(1L, "TestUser", false);
+        telegramMessage.setFrom(user);
+        update.setMessage(telegramMessage);
+
+        // Add user to the test database
+        UserEntity userEntity = new UserEntity();
+        userEntity.setUserId(user.getId());
+        userEntity.setEmail("allowed1@example.com");
+        userEntity.setFirstName(user.getFirstName());
+        userEntity.setLastName(user.getLastName());
+        userEntity.setUserName(user.getUserName());
+        userRepository.save(userEntity);
+
+        ArgumentCaptor<SendMessage> argumentCaptor = ArgumentCaptor.forClass(SendMessage.class);
+        org.mockito.Mockito.doReturn(null).when(telegramClient).execute(argumentCaptor.capture());
+
+        // when
+        telegramClientConfig.consume(update);
+
+        // then
+        SendMessage capturedMessage = argumentCaptor.getValue();
+        assertThat(capturedMessage).isNotNull();
+        assertThat(capturedMessage.getText()).isEqualTo("Tarea modificada correctamente.");
+    }
+
+    @Test
+    void testDeleteTaskResponse() throws Exception {
+        // given
+        String message = "Elimina la tarea existente";
+        Update update = new Update();
+        Message telegramMessage = new Message();
+        telegramMessage.setText(message);
+        telegramMessage.setChat(new Chat(9L, "private"));
+        User user = new User(1L, "TestUser", false);
+        telegramMessage.setFrom(user);
+        update.setMessage(telegramMessage);
+
+        // Add user to the test database
+        UserEntity userEntity = new UserEntity();
+        userEntity.setUserId(user.getId());
+        userEntity.setEmail("allowed1@example.com");
+        userEntity.setFirstName(user.getFirstName());
+        userEntity.setLastName(user.getLastName());
+        userEntity.setUserName(user.getUserName());
+        userRepository.save(userEntity);
+
+        ArgumentCaptor<SendMessage> argumentCaptor = ArgumentCaptor.forClass(SendMessage.class);
+        org.mockito.Mockito.doReturn(null).when(telegramClient).execute(argumentCaptor.capture());
+
+        // when
+        telegramClientConfig.consume(update);
+
+        // then
+        SendMessage capturedMessage = argumentCaptor.getValue();
+        assertThat(capturedMessage).isNotNull();
+        assertThat(capturedMessage.getText()).isEqualTo("Tarea eliminada correctamente.");
+    }
+
+    @Test
+    void testSelectQueryResponse() throws Exception {
+        // given
+        String message = "Muéstrame todas las tareas";
+        Update update = new Update();
+        Message telegramMessage = new Message();
+        telegramMessage.setText(message);
+        telegramMessage.setChat(new Chat(9L, "private"));
+        User user = new User(1L, "TestUser", false);
+        telegramMessage.setFrom(user);
+        update.setMessage(telegramMessage);
+
+        // Add user to the test database
+        UserEntity userEntity = new UserEntity();
+        userEntity.setUserId(user.getId());
+        userEntity.setEmail("allowed1@example.com");
+        userEntity.setFirstName(user.getFirstName());
+        userEntity.setLastName(user.getLastName());
+        userEntity.setUserName(user.getUserName());
+        userRepository.save(userEntity);
+
+        ArgumentCaptor<SendMessage> argumentCaptor = ArgumentCaptor.forClass(SendMessage.class);
+        org.mockito.Mockito.doReturn(null).when(telegramClient).execute(argumentCaptor.capture());
+
+        // when
+        telegramClientConfig.consume(update);
+
+        // then
+        SendMessage capturedMessage = argumentCaptor.getValue();
+        assertThat(capturedMessage).isNotNull();
+        assertThat(capturedMessage.getText()).contains("Resultados:");
+    }
 }


### PR DESCRIPTION
…appropriate responses

* Add `generateResponseMessage` method to identify SQL query type and return corresponding messages for create, update, and delete operations
* Modify `processUserMessage` method to use `generateResponseMessage` and return appropriate response

Update tests in `ManagerAgentTestIT` to verify correct responses for different SQL query types

* Replace assertions to check for specific response messages for create, update, and delete operations

Add tests in `TelegramClientConfigTestIT` to verify `consume` method handles different responses correctly

* Add tests for create, update, delete, and select query responses
* Ensure tests check for appropriate messages and task listing only for select queries